### PR TITLE
Suppress 'deprecated' warnings category

### DIFF
--- a/lib/App/perlhl.pm
+++ b/lib/App/perlhl.pm
@@ -1,6 +1,7 @@
 package App::perlhl;
 use strict;
 use warnings;
+no warnings 'deprecated';
 use v5.10.1;
 no if ($] >= 5.017010), warnings => 'experimental::smartmatch';
 use Syntax::Highlight::Perl::Improved 1.01 ();


### PR DESCRIPTION
The 'given - when - default' syntax (use in lib/App/perlhl.pm) will be deprecated in perl-5.38.0 and warnings will be generated whenever encountered.  The test suite in this distribution depends on matching test output to expectations.  So the only way, in the short-term, to have tests continue to pass is to suppress those warnings in the module.